### PR TITLE
>deb atalho para debugger;

### DIFF
--- a/debugger.sublime-snippet
+++ b/debugger.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[debugger;$0]]></content>
+	<tabTrigger><![CDATA[>deb]]></tabTrigger>
+	<scope>source.js</scope>
+	<description>debugger;</description>
+</snippet>


### PR DESCRIPTION
Gostei muito destes snippets, a unica coisa que notei é que um que eu uso bastante e não esta aqui é o `debugger;` mesmo saindo um pouco do foco console, acredito que é valido ter ele aqui.
